### PR TITLE
Delay the shutdown and restart so cbadmin gets a response.

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -230,15 +230,15 @@ doCommand.sync = function() {
 
 //DICT:DO:shutdown: Halt system
 doCommand.shutdown = function() {
-	return(execute(`sudo shutdown -h now &`))
+  setTimeout(() => execute(`sudo shutdown -h now &`), 1000);
+	return(true)
 }
 
 //DICT:DO:reboot: Reboot
 doCommand.reboot = function() {
-	return(execute(`sudo shutdown -r now &`))
+  setTimeout(() => execute(`sudo shutdown -r now &`), 1000);
+ 	return(true);
 }
-
-
 
 //DICT:GET:subscriptions: Returns a list of subscriptions available on the server
 get.subscriptions = function() {


### PR DESCRIPTION
Here is a recommended enhancement.  I noticed when I make a request to restart from cbadmin, an error displays with a timeout.  This happens because the box restarts before sending a response.  I recommend delaying the restart and shutdown for a second, and send a response.